### PR TITLE
Use maven shade plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ local.properties
 
 # Hidden files
 .DS_Store
+
+dependency-reduced-pom.xml
+models2pathways.tsv
+analysis*bin

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,9 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>org.reactome.server.tools</groupId>
     <artifactId>Models2Pathways</artifactId>
     <version>1.0</version>
-
     <dependencies>
         <dependency>
             <groupId>org.sbml.jsbml</groupId>
@@ -89,7 +87,6 @@
             <version>1.6.0</version>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -99,33 +96,6 @@
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <!-- Build an executable JAR -->
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>lib/</classpathPrefix>
-                            <mainClass>org.reactome.server.models2pathways.core.entrypoint.Models2Pathways</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <!-- this is used for inheritance merges -->
-                        <phase>package</phase>
-                        <!-- bind to the packaging phase -->
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -143,6 +113,37 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.handlers</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/spring.schemas</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>org.reactome.server.models2pathways.core.entrypoint.Models2Pathways</Main-Class>
+                                        <X-Compile-Source-JDK>${maven.compile.source}</X-Compile-Source-JDK>
+                                        <X-Compile-Target-JDK>${maven.compile.target}</X-Compile-Target-JDK>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -151,7 +152,6 @@
             </resource>
         </resources>
     </build>
-
     <repositories>
         <repository>
             <id>central</id>
@@ -162,7 +162,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-
         <repository>
             <id>central_1</id>
             <name>Maven Repository Switchboard</name>
@@ -196,18 +195,18 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
-
         <repository>
             <id>ebi-repo-mvn</id>
             <name>The EBI repository</name>
             <url>http://www.ebi.ac.uk/~maven/m2repo</url>
-            <releases><enabled>true</enabled></releases>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
-
         <repository>
             <id>biojava-legacy-repo</id>
             <name>BioJava's Git based legacy maven repo</name>
             <url>https://github.com/biojava/maven-repo/raw/master/</url>
         </repository>
     </repositories>
-</project>
+    </project>


### PR DESCRIPTION
I was having problems with missing spring handlers. This can sometimes happen when multiple spring dependencies contain properties files with the same name but different contents: building the final jar can result in the maven assembly plugin overwriting one spring properties with another of the same name.
The maven shade plugin helps resolve this.
For more about this problem, see: https://stackoverflow.com/q/19615698 for an example of the problem and solution.